### PR TITLE
Reduce hero whitespace

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -113,7 +113,7 @@ const Hero = () => {
 
   return (
 
-    <section id="hero" className="relative min-h-[70vh] bg-cover bg-center bg-no-repeat flex items-start pt-10 sm:pt-12">
+    <section id="hero" className="relative min-h-[50vh] bg-cover bg-center bg-no-repeat flex items-start pt-10 sm:pt-12">
 
       {/* Background image as actual <Image> for proper LCP and preload */}
       <div className="absolute inset-0 hero-bg">


### PR DESCRIPTION
This PR reduces the hero section's minimum height from 70vh to 50vh to remove excess bottom whitespace on the homepage.